### PR TITLE
Use MetadataLoader in ErrorListener

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -36,6 +36,48 @@ services:
 
 > Аргументы `$translator` и `$expressionLanguage` не обязательны
 
+В качестве третьего аргумента `$metadataLoader` можно передать инстанс
+`Kenny1911\SymfonyHttpException\Metadata\MetadataLoader`. По-умолчанию используется `AttributeMetadataLoader`. Помимо
+этого также есть:
+
+- `ArrayMetadataLoader` - использует сопоставление (map) класса исключения к объекту `BaseHttpException`.
+- `ConfigMetadataLoader` - использует ассоциативный массив для описания конфигурации.
+- `ChainMetadataLoader` - объединяет в себе несколько `MetadataLoader`. 
+
+This loaders can be used for describe third-party exceptions.
+
+Пример расширенной конфигурации:
+
+```yaml
+# config/services.yaml
+services:
+    Kenny1911\SymfonyHttpException\ErrorListener:
+        arguments:
+          - '@translator'
+          - !service { class: Symfony\Component\ExpressionLanguage\ExpressionLanguage }
+          - !service
+            class: Kenny1911\SymfonyHttpException\Metadata\ChainMetadataLoader
+            arguments:
+              - !service { class: Kenny1911\SymfonyHttpException\Metadata\ArrayMetadataLoader }
+              - !service
+                class: Kenny1911\SymfonyHttpException\Metadata\ConfigMetadataLoader
+                arguments:
+                  - App\Exceptions\SomeException:
+                      statusCode: 401
+                      message: 'Not authorized. Error code: { error_code }. { exception_message }'
+                      parameters:
+                        '{ error_code }': '10420'
+                        '{ exception_message }': 'expr(e.getMessage())'
+                      translationDomain: message
+                      headers:
+                        'X-Error-Code': '10420'
+                        'X-Error-Message': 'expr(e.getMessage())'
+                    App\Exceptions\OtherException:
+                      statusCode: 400
+        tags:
+            - { name: kernel.event_subscriber }
+```
+
 ## Использование
 
 ### Минимальный пример
@@ -101,6 +143,8 @@ use Kenny1911\SymfonyHttpException\Attribute\BadRequestHttpException;
 #[BadRequestHttpException]
 final class InvalidUsernameException extends Exception {}
 ```
+
+TODO Описать использование другие MetadataLoader: ArrayMetadataLoader, ConfigMetadataLoader и ChainMetadataLoader
 
 ## Лицензия
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,47 @@ services:
 
 > Arguments `$translator` and `$expressionLanguage` is not required
 
+As the third argument `$metadataLoader`, you can pass the instance of `Kenny1911\SymfonyHttpException\Metadata\MetadataLoader`.
+The default value is `AttributeMetadataLoader`. Apart from this, there is also:
+
+- `ArrayMetadataLoader` - use map exception class to `BaseHttpException` instance.
+- `ConfigMetadataLoader` - use associative array for describe configuration.
+- `ChainMetadataLoader` - combine multiply `MetadataLoader` instances.
+
+Эти загрузчики могут использоваться для описания сторонних классов исключения.
+
+Example of advanced configuration:
+
+```yaml
+# config/services.yaml
+services:
+    Kenny1911\SymfonyHttpException\ErrorListener:
+        arguments:
+          - '@translator'
+          - !service { class: Symfony\Component\ExpressionLanguage\ExpressionLanguage }
+          - !service
+            class: Kenny1911\SymfonyHttpException\Metadata\ChainMetadataLoader
+            arguments:
+              - !service { class: Kenny1911\SymfonyHttpException\Metadata\ArrayMetadataLoader }
+              - !service
+                class: Kenny1911\SymfonyHttpException\Metadata\ConfigMetadataLoader
+                arguments:
+                  - App\Exceptions\SomeException:
+                      statusCode: 401
+                      message: 'Not authorized. Error code: { error_code }. { exception_message }'
+                      parameters:
+                        '{ error_code }': '10420'
+                        '{ exception_message }': 'expr(e.getMessage())'
+                      translationDomain: message
+                      headers:
+                        'X-Error-Code': '10420'
+                        'X-Error-Message': 'expr(e.getMessage())'
+                    App\Exceptions\OtherException:
+                      statusCode: 400
+        tags:
+            - { name: kernel.event_subscriber }
+```
+
 ## Usage
 
 ### Basic Example

--- a/src/ErrorListener.php
+++ b/src/ErrorListener.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Kenny1911\SymfonyHttpException;
 
-use Kenny1911\SymfonyHttpException\Attribute\BaseHttpException;
 use Kenny1911\SymfonyHttpException\ExpressionLanguage\Expression;
+use Kenny1911\SymfonyHttpException\Metadata\AttributeMetadataLoader;
+use Kenny1911\SymfonyHttpException\Metadata\MetadataLoader;
 use Kenny1911\SymfonyHttpException\Translation\SimpleTranslator;
 use Kenny1911\SymfonyHttpException\Translation\TranslatorDecorator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -23,6 +24,7 @@ final class ErrorListener implements EventSubscriberInterface
     public function __construct(
         private readonly TranslatorInterface $translator = new SimpleTranslator(),
         private readonly ?ExpressionLanguage $expressionLanguage = null,
+        private readonly MetadataLoader $metadataLoader = new AttributeMetadataLoader(),
     ) {}
 
     public static function getSubscribedEvents(): array
@@ -43,34 +45,25 @@ final class ErrorListener implements EventSubscriberInterface
             return;
         }
 
-        $refClass = new \ReflectionClass($throwable::class);
+        $httpException = $this->metadataLoader->load($throwable::class);
 
-        do {
-            $attribute = $refClass->getAttributes(BaseHttpException::class, \ReflectionAttribute::IS_INSTANCEOF)[0] ?? null;
+        if (null === $httpException) {
+            return;
+        }
 
-            if (null === $attribute) {
-                continue;
-            }
+        $translator = new TranslatorDecorator($this->translator, $httpException->translationDomain);
 
-            /** @var BaseHttpException $httpException */
-            $httpException = $attribute->newInstance();
+        $parameters = array_map(fn(string|Expression $p): string => $this->exec($p, $throwable, $translator), $httpException->parameters);
+        $message = $translator->trans($httpException->message ?? $throwable->getMessage(), $parameters, $httpException->translationDomain);
+        $headers = array_map(fn(string|Expression $p): string => $this->exec($p, $throwable, $translator), $httpException->headers);
 
-            $translator = new TranslatorDecorator($this->translator, $httpException->translationDomain);
-
-            $parameters = array_map(fn(string|Expression $p): string => $this->exec($p, $throwable, $translator), $httpException->parameters);
-            $message = $translator->trans($httpException->message ?? $throwable->getMessage(), $parameters, $httpException->translationDomain);
-            $headers = array_map(fn(string|Expression $p): string => $this->exec($p, $throwable, $translator), $httpException->headers);
-
-            $event->setThrowable(new HttpException(
-                statusCode: $httpException->statusCode,
-                message: $message,
-                previous: $throwable,
-                headers: $headers,
-                code: (int) $throwable->getCode(),
-            ));
-
-            break;
-        } while ($refClass = $refClass->getParentClass());
+        $event->setThrowable(new HttpException(
+            statusCode: $httpException->statusCode,
+            message: $message,
+            previous: $throwable,
+            headers: $headers,
+            code: (int) $throwable->getCode(),
+        ));
     }
 
     private function exec(string|Expression $expression, \Throwable $throwable, TranslatorInterface $translator): string

--- a/src/Metadata/ArrayMetadataLoader.php
+++ b/src/Metadata/ArrayMetadataLoader.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kenny1911\SymfonyHttpException\Metadata;
+
+use Kenny1911\SymfonyHttpException\Attribute\BaseHttpException;
+
+/**
+ * @api
+ */
+final class ArrayMetadataLoader implements MetadataLoader
+{
+    /**
+     * @param array<class-string<\Throwable>, BaseHttpException> $metadata
+     */
+    public function __construct(
+        private readonly array $metadata,
+    ) {}
+
+    public function load(string $class): ?BaseHttpException
+    {
+        return $this->metadata[$class] ?? null;
+    }
+}

--- a/src/Metadata/AttributeMetadataLoader.php
+++ b/src/Metadata/AttributeMetadataLoader.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kenny1911\SymfonyHttpException\Metadata;
+
+use Kenny1911\SymfonyHttpException\Attribute\BaseHttpException;
+
+/**
+ * @api
+ */
+final class AttributeMetadataLoader implements MetadataLoader
+{
+    /**
+     * @throws \ReflectionException
+     */
+    public function load(string $class): ?BaseHttpException
+    {
+        $refClass = new \ReflectionClass($class);
+
+        do {
+            $attribute = $refClass->getAttributes(BaseHttpException::class, \ReflectionAttribute::IS_INSTANCEOF)[0] ?? null;
+
+            if (null === $attribute) {
+                continue;
+            }
+
+            return $attribute->newInstance();
+        } while ($refClass = $refClass->getParentClass());
+
+        return null;
+    }
+}

--- a/src/Metadata/ChainMetadataLoader.php
+++ b/src/Metadata/ChainMetadataLoader.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kenny1911\SymfonyHttpException\Metadata;
+
+use Kenny1911\SymfonyHttpException\Attribute\BaseHttpException;
+
+/**
+ * @api
+ */
+final class ChainMetadataLoader implements MetadataLoader
+{
+    /**
+     * @param iterable<MetadataLoader> $loaders
+     */
+    public function __construct(
+        private readonly iterable $loaders,
+    ) {}
+
+    public function load(string $class): ?BaseHttpException
+    {
+        foreach ($this->loaders as $loader) {
+            $httpException = $loader->load($class);
+
+            if ($httpException instanceof BaseHttpException) {
+                return $httpException;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Metadata/ConfigMetadataLoader.php
+++ b/src/Metadata/ConfigMetadataLoader.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kenny1911\SymfonyHttpException\Metadata;
+
+use Kenny1911\SymfonyHttpException\Attribute\BaseHttpException;
+use Kenny1911\SymfonyHttpException\Attribute\HttpException;
+use Kenny1911\SymfonyHttpException\ExpressionLanguage\Expression;
+
+/**
+ * @api
+ */
+final class ConfigMetadataLoader implements MetadataLoader
+{
+    private const EXPR_REGEX = '/^expr\((?P<expr>.+)\)$/';
+
+    private ArrayMetadataLoader $loader;
+
+    /**
+     * @param array<class-string<\Throwable>, array{
+     *     statusCode: int<400, 599>,
+     *     message?: string,
+     *     parameters?: array<non-empty-string, non-empty-string>,
+     *     translationDomain?: string,
+     *     headers?: array<non-empty-string, non-empty-string>
+     * }> $config
+     */
+    public function __construct(array $config)
+    {
+        $metadata = array_map(
+            static fn($classConfig) => new HttpException(
+                statusCode: $classConfig['statusCode'],
+                message: $classConfig['message'] ?? null,
+                parameters: array_map(self::prepareParameter(...), $classConfig['parameters'] ?? []),
+                translationDomain: $classConfig['translationDomain'] ?? 'http_message',
+                headers: array_map(self::prepareParameter(...), $classConfig['headers'] ?? []),
+            ),
+            $config,
+        );
+
+        $this->loader = new ArrayMetadataLoader($metadata);
+    }
+
+    public function load(string $class): ?BaseHttpException
+    {
+        return $this->loader->load($class);
+    }
+
+    /**
+     * @param non-empty-string $parameter
+     * @return Expression|non-empty-string
+     */
+    private static function prepareParameter(string $parameter): Expression|string
+    {
+        if (preg_match(self::EXPR_REGEX, $parameter, $matches)) {
+            return new Expression($matches['expr']);
+        }
+
+        return $parameter;
+    }
+}

--- a/src/Metadata/MetadataLoader.php
+++ b/src/Metadata/MetadataLoader.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kenny1911\SymfonyHttpException\Metadata;
+
+use Kenny1911\SymfonyHttpException\Attribute\BaseHttpException;
+
+/**
+ * @api
+ */
+interface MetadataLoader
+{
+    /**
+     * @param class-string<\Throwable> $class
+     */
+    public function load(string $class): ?BaseHttpException;
+}

--- a/tests/ErrorListenerTest.php
+++ b/tests/ErrorListenerTest.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace Kenny1911\SymfonyHttpException\Tests;
 
 use Kenny1911\SymfonyHttpException\ErrorListener;
+use Kenny1911\SymfonyHttpException\ExpressionLanguage\Expression;
+use Kenny1911\SymfonyHttpException\Metadata\ArrayMetadataLoader;
+use Kenny1911\SymfonyHttpException\Metadata\AttributeMetadataLoader;
+use Kenny1911\SymfonyHttpException\Metadata\ChainMetadataLoader;
+use Kenny1911\SymfonyHttpException\Metadata\ConfigMetadataLoader;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
@@ -108,6 +113,22 @@ final class ErrorListenerTest extends TestCase
         400,
         [],
     ])]
+    #[TestWith([
+        new TestExceptionFromArrayMetadataLoader('Orig message, using array'),
+        true,
+        true,
+        'Trans(test): Not authorized. Orig message, using array',
+        401,
+        ['X-Exception-Message' => 'Orig message, using array'],
+    ])]
+    #[TestWith([
+        new TestExceptionFromConfigMetadataLoader('Orig message, using array'),
+        true,
+        true,
+        'Trans(test): Not authorized. Orig message, using array',
+        401,
+        ['X-Exception-Message' => 'Orig message, using array'],
+    ])]
     public function test(
         \Throwable $throwable,
         bool $supportTranslation,
@@ -125,6 +146,27 @@ final class ErrorListenerTest extends TestCase
         $listener = new ErrorListener(
             translator: $supportTranslation ? self::createTranslator() : $defaultTranslator,
             expressionLanguage: $supportExpressionLanguage ? new ExpressionLanguage() : null,
+            metadataLoader: new ChainMetadataLoader([
+                new AttributeMetadataLoader(),
+                new ArrayMetadataLoader([
+                    TestExceptionFromArrayMetadataLoader::class => new \Kenny1911\SymfonyHttpException\Attribute\HttpException(
+                        statusCode: 401,
+                        message: 'Not authorized. { exception_message }',
+                        parameters: ['{ exception_message }' => new Expression('e.getMessage()')],
+                        translationDomain: 'test',
+                        headers: ['X-Exception-Message' => new Expression('e.getMessage()')],
+                    ),
+                ]),
+                new ConfigMetadataLoader([
+                    TestExceptionFromConfigMetadataLoader::class => [
+                        'statusCode' => 401,
+                        'message' => 'Not authorized. { exception_message }',
+                        'parameters' => ['{ exception_message }' => 'expr(e.getMessage())'],
+                        'translationDomain' => 'test',
+                        'headers' => ['X-Exception-Message' => 'expr(e.getMessage())'],
+                    ],
+                ]),
+            ]),
         );
 
         $event = (new \ReflectionClass(ExceptionEvent::class))->newInstanceWithoutConstructor();

--- a/tests/TestExceptionFromArrayMetadataLoader.php
+++ b/tests/TestExceptionFromArrayMetadataLoader.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kenny1911\SymfonyHttpException\Tests;
+
+/**
+ * @api
+ */
+final class TestExceptionFromArrayMetadataLoader extends \Exception {}

--- a/tests/TestExceptionFromConfigMetadataLoader.php
+++ b/tests/TestExceptionFromConfigMetadataLoader.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kenny1911\SymfonyHttpException\Tests;
+
+/**
+ * @api
+ */
+final class TestExceptionFromConfigMetadataLoader extends \Exception {}


### PR DESCRIPTION
`AttributeMetadataLoader` is default metadata loader, that used attributes for describe http exceptions.

Other metadata loaders (`ArrayMetadataLoader` and `ConfigMetadataLoader`) can be used to describe third-party exceptions, that you can't add `HttpException` attributes:

`ChainMetadataLoader` used to combine multiply loaders.